### PR TITLE
Add stress_statefile resource to workout statefile writing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # terraform-provider-stress
 Terrifying Terraforming Tricks To Test TFE's Tenacity
 
-This is a very simple provider that exists to do synthetic stress testing against Terraform Enterprise installations. It is very WIP and very ill advised to actually use. It does simple things like allocate and hold on to memory and stress out CPUs for durations. This is an unpublished module and at the moment it is only used for [sideloading](https://www.terraform.io/docs/configuration/providers.html#third-party-plugins) into local runs or using the `terraform.d/` dir to load a Linux version of it into TFE (other methods would be to use bundles etc). 
+This is a very simple provider that exists to do synthetic stress testing against Terraform Enterprise installations. It is very WIP and very ill advised to actually use. It does simple things like allocate and hold on to memory and stress out CPUs for durations. This is an unpublished module and at the moment it is only used for [sideloading](https://www.terraform.io/docs/configuration/providers.html#third-party-plugins) into local runs or using the `terraform.d/` dir to load a Linux version of it into TFE (other methods would be to use bundles etc).
 
-At the moment only a couple things are supported, `resource_stress_memory` and `resource_stress_cpu`. In the future things like disk/state file stresses will be added as needed but this is a good start. 
+At the moment only a couple things are supported, `resource_stress_memory` and `resource_stress_cpu`. In the future things like disk/state file stresses will be added as needed but this is a good start.
 
 ## Usage
 
-Don't. 
+Don't.
 
 ## But if you must
 
@@ -18,6 +18,11 @@ resource "stress_cpu" "why-are-you-doing-this" {
 
 resource "stress_memory" "sad-ram-dot-emoji" {
   duration = 300 # How long to hold the memory
-  size = 128 # Memory to allocate in MB 
+  size = 128 # Memory to allocate in MB
+}
+
+resource "stress_statefile" "this-can-crash-tf" {
+  count = 64 # adjust count to adjust bloat, but careful this is not linear for the RAM consumed
+  size = 2 # 2MB, do not go over 3 as there is a size limit for setting attributes over grpc of ~4MB
 }
 ```

--- a/main.tf
+++ b/main.tf
@@ -5,7 +5,7 @@ variable "cpu_stress_duration" {
 
 variable "memory_stress_duration" {
   type = number
-  default = "300"
+  default = "1"
 }
 
 variable "memory_stress_size" {
@@ -20,4 +20,10 @@ resource "stress_cpu" "my-server" {
 resource "stress_memory" "memory" {
   duration = var.memory_stress_duration
   size = var.memory_stress_size
+}
+
+resource "stress_statefile" "statefile" {
+  count = 64
+  // Bigger than 3mb and you'll start seeing the RPC connection between tf and the provider break due to the 4mb limit
+  size = 1
 }

--- a/provider.go
+++ b/provider.go
@@ -9,6 +9,7 @@ func Provider() *schema.Provider {
 		ResourcesMap: map[string]*schema.Resource{
 			"stress_cpu":    resourceCpu(),
 			"stress_memory": resourceMemory(),
+			"stress_statefile": resourceStatefile(),
 		},
 	}
 }

--- a/resource_statefile.go
+++ b/resource_statefile.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"fmt"
+	"math/rand"
+	"time"
+
+	petname "github.com/dustinkirkland/golang-petname"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceStatefile() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceStatefileCreate,
+		Read:   resourceStatefileRead,
+		Update: resourceStatefileUpdate,
+		Delete: resourceStatefileDelete,
+
+		Schema: map[string]*schema.Schema{
+			"size": &schema.Schema{
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+      "data": &schema.Schema{
+        Type: schema.TypeList,
+        Computed: true,
+        Elem: &schema.Schema{
+          Type: schema.TypeString,
+        },
+      },
+		},
+	}
+}
+
+func resourceStatefileCreate(d *schema.ResourceData, m interface{}) error {
+	size := d.Get("size").(int)
+	sizeInBytes := size * (1024 * 1024)
+  numberOfStrings := sizeInBytes / 4096
+  const fourKString = "All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy All work and no play makes Jack a dull boy "
+
+  // taken from https://golang.org/src/bytes/buffer_test.go
+  var stateFileStrings []string //[2097152]string // 8gb / 4k
+	for i := 0; i < numberOfStrings; i++ {
+    stateFileStrings = append(stateFileStrings, fourKString)
+    //log.Printf("%v", stateFileStrings)
+	}
+
+  if err := d.Set("data", stateFileStrings); err != nil {
+    return fmt.Errorf("Error setting data: %s", err)
+  }
+
+	rand.Seed(time.Now().UTC().UnixNano())
+	id := petname.Generate(3, "-")
+	d.SetId(id)
+
+	return resourceStatefileRead(d, m)
+}
+
+func resourceStatefileRead(d *schema.ResourceData, m interface{}) error {
+	return nil
+}
+
+func resourceStatefileUpdate(d *schema.ResourceData, m interface{}) error {
+	return nil
+}
+
+func resourceStatefileDelete(d *schema.ResourceData, m interface{}) error {
+	return nil
+}
+


### PR DESCRIPTION
One of the things I'd like to test is TF behaves when statefiles get very large. This is not a realistic test as it uses ~4K strings to pad out lists 1-3MB at a time. But it does put a lot of stress on RAM and create some larger statefiles. 

I've heard reports of multiple gig statefiles (which I'm very curious about), but at this point I see TF crashing even as I push 128-256MB through this resource. Still refining this bit of evil but might be useful to see hotspots with larger files traveling around the system. 